### PR TITLE
Supply history

### DIFF
--- a/pallets/dao-assets/src/functions.rs
+++ b/pallets/dao-assets/src/functions.rs
@@ -2,6 +2,8 @@
 
 use super::*;
 use frame_support::{traits::Get, BoundedVec};
+use frame_system::pallet_prelude::BlockNumberFor;
+use sp_std::borrow::Borrow;
 
 #[must_use]
 pub(super) enum DeadConsequence {
@@ -16,28 +18,22 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	// Public immutables
 
 	/// Get the asset `id` free balance of `who`, or zero if the asset-account doesn't exist.
-	pub fn balance(id: T::AssetId, who: impl sp_std::borrow::Borrow<T::AccountId>) -> T::Balance {
+	pub fn balance(id: T::AssetId, who: impl Borrow<T::AccountId>) -> T::Balance {
 		Self::maybe_balance(id, who).unwrap_or_default()
 	}
 
 	/// Get the asset `id` reserved balance of `who`, or zero if the asset-account doesn't exist.
-	pub fn reserved(id: T::AssetId, who: impl sp_std::borrow::Borrow<T::AccountId>) -> T::Balance {
+	pub fn reserved(id: T::AssetId, who: impl Borrow<T::AccountId>) -> T::Balance {
 		Self::maybe_reserved(id, who).unwrap_or_default()
 	}
 
 	/// Get the asset `id` free balance of `who` if the asset-account exists.
-	pub fn maybe_balance(
-		id: T::AssetId,
-		who: impl sp_std::borrow::Borrow<T::AccountId>,
-	) -> Option<T::Balance> {
+	pub fn maybe_balance(id: T::AssetId, who: impl Borrow<T::AccountId>) -> Option<T::Balance> {
 		Account::<T, I>::get(id, who.borrow()).map(|a| a.balance)
 	}
 
 	/// Get the asset `id` reserved balance of `who` if the asset-account exists.
-	pub fn maybe_reserved(
-		id: T::AssetId,
-		who: impl sp_std::borrow::Borrow<T::AccountId>,
-	) -> Option<T::Balance> {
+	pub fn maybe_reserved(id: T::AssetId, who: impl Borrow<T::AccountId>) -> Option<T::Balance> {
 		Account::<T, I>::get(id, who.borrow()).map(|a| a.reserved)
 	}
 
@@ -53,7 +49,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	pub(super) fn new_account(
 		who: &T::AccountId,
-		d: &mut AssetDetails<T::Balance, T::AccountId, DepositBalanceOf<T, I>>,
+		d: &mut AssetDetailsOf<T, I>,
 		maybe_deposit: Option<DepositBalanceOf<T, I>>,
 	) -> Result<ExistenceReason<DepositBalanceOf<T, I>>, DispatchError> {
 		let accounts = d.accounts.checked_add(1).ok_or(ArithmeticError::Overflow)?;
@@ -73,7 +69,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	pub(super) fn dead_account(
 		who: &T::AccountId,
-		d: &mut AssetDetails<T::Balance, T::AccountId, DepositBalanceOf<T, I>>,
+		d: &mut AssetDetailsOf<T, I>,
 		reason: &ExistenceReason<DepositBalanceOf<T, I>>,
 		force: bool,
 	) -> DeadConsequence {
@@ -272,11 +268,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Account::<T, I>::insert(
 			id,
 			&who,
-			AssetAccountOf::<T, I> {
-				balance: Zero::zero(),
-				reserved: Zero::zero(),
-				reason,
-			},
+			AssetAccountOf::<T, I> { balance: Zero::zero(), reserved: Zero::zero(), reason },
 		);
 		Ok(())
 	}
@@ -341,7 +333,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		beneficiary: &T::AccountId,
 		amount: T::Balance,
 		check: impl FnOnce(
-			&mut AssetDetails<T::Balance, T::AccountId, DepositBalanceOf<T, I>>,
+			&mut AssetDetailsOf<T, I>,
 		) -> DispatchResult,
 	) -> DispatchResult {
 		if amount.is_zero() {
@@ -423,7 +415,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		f: DebitFlags,
 		check: impl FnOnce(
 			T::Balance,
-			&mut AssetDetails<T::Balance, T::AccountId, DepositBalanceOf<T, I>>,
+			&mut AssetDetailsOf<T, I>,
 		) -> DispatchResult,
 	) -> Result<T::Balance, DispatchError> {
 		if amount.is_zero() {
@@ -466,7 +458,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Reserves some `amount` of asset `id` balance of `target`.
 	pub fn do_reserve(
 		id: T::AssetId,
-		target: impl sp_std::borrow::Borrow<T::AccountId>,
+		target: impl Borrow<T::AccountId>,
 		amount: T::Balance,
 	) -> Result<T::Balance, DispatchError> {
 		if amount.is_zero() {
@@ -498,7 +490,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// If `amount` is greater than reserved balance, then the whole reserved balance is unreserved.
 	pub fn do_unreserve(
 		id: T::AssetId,
-		target: impl sp_std::borrow::Borrow<T::AccountId>,
+		target: impl Borrow<T::AccountId>,
 		mut amount: T::Balance,
 	) -> Result<T::Balance, DispatchError> {
 		if amount.is_zero() {
@@ -680,7 +672,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Destroy accounts associated with a given asset up to the max (T::RemoveItemsLimit).
 	///
-	/// Each call emits the `Event::DestroyedAccounts` event.
+	/// Each call emits the `Event::AccountsDestroyed` event.
 	/// Returns the number of destroyed accounts.
 	pub(super) fn do_destroy_accounts(
 		id: T::AssetId,
@@ -690,6 +682,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let mut remaining_accounts = 0;
 		Asset::<T, I>::try_mutate_exists(id, |maybe_details| -> Result<(), DispatchError> {
 			let details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
+
 			// Should only destroy accounts while the asset is in a destroying state
 			ensure!(details.status == AssetStatus::Destroying, Error::<T, I>::IncorrectStatus);
 
@@ -714,7 +707,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Destroy approvals associated with a given asset up to the max (T::RemoveItemsLimit).
 	///
-	/// Each call emits the `Event::DestroyedApprovals` event
+	/// Each call emits the `Event::ApprovalsDestroyed` event
 	/// Returns the number of destroyed approvals.
 	pub(super) fn do_destroy_approvals(
 		id: T::AssetId,
@@ -761,6 +754,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				details.deposit.saturating_add(metadata.deposit),
 			);
 			details.status = AssetStatus::Destroyed;
+
 			Self::deposit_event(Event::Destroyed { asset_id: id });
 
 			Ok(())

--- a/pallets/dao-assets/src/lib.rs
+++ b/pallets/dao-assets/src/lib.rs
@@ -852,7 +852,6 @@ pub mod pallet {
 		/// The origin must be Signed.
 		///
 		/// - `id`: The identifier of the asset for the account to be created.
-		/// - `allow_burn`: If `true` then assets may be destroyed in order to complete the refund.
 		///
 		/// Emits `Refunded` event when successful.
 		#[pallet::call_index(27)]
@@ -860,10 +859,9 @@ pub mod pallet {
 		pub fn refund(
 			origin: OriginFor<T>,
 			id: T::AssetIdParameter,
-			allow_burn: bool,
 		) -> DispatchResult {
 			let id: T::AssetId = id.into();
-			Self::do_refund(id, ensure_signed(origin)?, allow_burn)
+			Self::do_refund(id, ensure_signed(origin)?)
 		}
 	}
 }

--- a/pallets/dao-assets/src/lib.rs
+++ b/pallets/dao-assets/src/lib.rs
@@ -292,9 +292,17 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// Some asset class was created.
-		Created { asset_id: T::AssetId, creator: T::AccountId, owner: T::AccountId },
+		Created {
+			asset_id: T::AssetId,
+			creator: T::AccountId,
+			owner: T::AccountId,
+		},
 		/// Some assets were issued.
-		Issued { asset_id: T::AssetId, owner: T::AccountId, total_supply: T::Balance },
+		Issued {
+			asset_id: T::AssetId,
+			owner: T::AccountId,
+			total_supply: T::Balance,
+		},
 		/// Some assets were transferred.
 		Transferred {
 			asset_id: T::AssetId,
@@ -303,7 +311,11 @@ pub mod pallet {
 			amount: T::Balance,
 		},
 		/// Some assets were destroyed.
-		Burned { asset_id: T::AssetId, owner: T::AccountId, balance: T::Balance },
+		Burned {
+			asset_id: T::AssetId,
+			owner: T::AccountId,
+			balance: T::Balance,
+		},
 		/// The management team changed.
 		TeamChanged {
 			asset_id: T::AssetId,
@@ -311,8 +323,15 @@ pub mod pallet {
 			admin: T::AccountId,
 		},
 		/// The owner changed.
-		OwnerChanged { asset_id: T::AssetId, owner: T::AccountId },
-		AccountsDestroyed { asset_id: T::AssetId, accounts_destroyed: u32, accounts_remaining: u32 },
+		OwnerChanged {
+			asset_id: T::AssetId,
+			owner: T::AccountId,
+		},
+		AccountsDestroyed {
+			asset_id: T::AssetId,
+			accounts_destroyed: u32,
+			accounts_remaining: u32,
+		},
 		/// Approvals were destroyed for given asset.
 		ApprovalsDestroyed {
 			asset_id: T::AssetId,
@@ -320,11 +339,18 @@ pub mod pallet {
 			approvals_remaining: u32,
 		},
 		/// An asset class is in the process of being destroyed.
-		DestructionStarted { asset_id: T::AssetId },
+		DestructionStarted {
+			asset_id: T::AssetId,
+		},
 		/// An asset class was destroyed.
-		Destroyed { asset_id: T::AssetId },
+		Destroyed {
+			asset_id: T::AssetId,
+		},
 		/// Some asset class was force-created.
-		ForceCreated { asset_id: T::AssetId, owner: T::AccountId },
+		ForceCreated {
+			asset_id: T::AssetId,
+			owner: T::AccountId,
+		},
 		/// New metadata has been set for an asset.
 		MetadataSet {
 			asset_id: T::AssetId,
@@ -333,7 +359,9 @@ pub mod pallet {
 			decimals: u8,
 		},
 		/// Metadata has been cleared for an asset.
-		MetadataCleared { asset_id: T::AssetId },
+		MetadataCleared {
+			asset_id: T::AssetId,
+		},
 		/// (Additional) funds have been approved for transfer to a destination account.
 		ApprovedTransfer {
 			asset_id: T::AssetId,
@@ -342,7 +370,11 @@ pub mod pallet {
 			amount: T::Balance,
 		},
 		/// An approval for account `delegate` was cancelled by `owner`.
-		ApprovalCancelled { asset_id: T::AssetId, owner: T::AccountId, delegate: T::AccountId },
+		ApprovalCancelled {
+			asset_id: T::AssetId,
+			owner: T::AccountId,
+			delegate: T::AccountId,
+		},
 		/// An `amount` was transferred in its entirety from `owner` to `destination` by
 		/// the approved `delegate`.
 		TransferredApproved {
@@ -353,7 +385,9 @@ pub mod pallet {
 			amount: T::Balance,
 		},
 		/// An asset has had its attributes changed by the `Force` origin.
-		AssetStatusChanged { asset_id: T::AssetId },
+		AssetStatusChanged {
+			asset_id: T::AssetId,
+		},
 	}
 
 	#[pallet::error]

--- a/pallets/dao-assets/src/lib.rs
+++ b/pallets/dao-assets/src/lib.rs
@@ -327,6 +327,7 @@ pub mod pallet {
 			asset_id: T::AssetId,
 			owner: T::AccountId,
 		},
+		/// Accounts were destroyed for given asset.
 		AccountsDestroyed {
 			asset_id: T::AssetId,
 			accounts_destroyed: u32,

--- a/pallets/dao-assets/src/lib.rs
+++ b/pallets/dao-assets/src/lib.rs
@@ -207,6 +207,12 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
+	#[pallet::storage]
+	#[pallet::unbounded]
+	/// History for the total supply across all accounts.
+	pub(super) type SupplyHistory<T: Config<I>, I: 'static = ()> =
+		StorageMap<_, Blake2_128Concat, T::AssetId, Vec<(BlockNumberFor<T>, AssetBalanceOf<T, I>)>>;
+
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config<I>, I: 'static = ()> {
 		/// Genesis assets: id, owner, is_sufficient, min_balance

--- a/pallets/dao-assets/src/tests.rs
+++ b/pallets/dao-assets/src/tests.rs
@@ -18,10 +18,13 @@ fn asset_ids() -> Vec<u32> {
 #[test]
 fn basic_minting_should_work() {
 	new_test_ext().execute_with(|| {
+		assert_eq!(Assets::total_historical_supply(0, System::block_number()), 0);
 		assert_ok!(Assets::do_force_create(0, 1, true, 1));
 		assert_ok!(Assets::do_mint(0, &1, 100, Some(1)));
+		assert_eq!(Assets::total_historical_supply(0, System::block_number()), 100);
 		assert_eq!(Assets::balance(0, 1), 100);
 		assert_ok!(Assets::do_mint(0, &2, 100, Some(1)));
+		assert_eq!(Assets::total_historical_supply(0, System::block_number()), 200);
 		assert_eq!(Assets::balance(0, 2), 100);
 		assert_eq!(asset_ids(), vec![0, 999]);
 	});
@@ -236,28 +239,29 @@ fn cancel_approval_works() {
 fn lifecycle_should_work() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&1, 100);
-		assert_ok!(Assets::do_force_create(0, 1, true, 1));
-		assert!(Asset::<Test>::contains_key(0));
+		let asset_id = 37;
+		assert_ok!(Assets::do_force_create(asset_id, 1, true, 1));
+		assert!(Asset::<Test>::contains_key(asset_id));
 
-		assert_ok!(Assets::set_metadata(RuntimeOrigin::signed(1), 0, vec![0], vec![0], 12));
+		assert_ok!(Assets::set_metadata(RuntimeOrigin::signed(1), asset_id, vec![0], vec![0], 12));
 		assert_eq!(Balances::reserved_balance(&1), 3);
-		assert!(Metadata::<Test>::contains_key(0));
+		assert!(Metadata::<Test>::contains_key(asset_id));
 
 		Balances::make_free_balance_be(&10, 100);
-		assert_ok!(Assets::do_mint(0, &10, 100, Some(1)));
+		assert_ok!(Assets::do_mint(asset_id, &10, 100, Some(1)));
 		Balances::make_free_balance_be(&20, 100);
-		assert_ok!(Assets::do_mint(0, &20, 100, Some(1)));
-		assert_eq!(Account::<Test>::iter_prefix(0).count(), 2);
+		assert_ok!(Assets::do_mint(asset_id, &20, 100, Some(1)));
+		assert_eq!(Account::<Test>::iter_prefix(asset_id).count(), 2);
 
-		assert_ok!(Assets::start_destroy(RuntimeOrigin::signed(1), 0));
-		assert_ok!(Assets::destroy_accounts(RuntimeOrigin::signed(1), 0));
-		assert_ok!(Assets::destroy_approvals(RuntimeOrigin::signed(1), 0));
-		assert_ok!(Assets::finish_destroy(RuntimeOrigin::signed(1), 0));
+		assert_ok!(Assets::start_destroy(RuntimeOrigin::signed(1), asset_id));
+		assert_ok!(Assets::destroy_accounts(RuntimeOrigin::signed(1), asset_id));
+		assert_ok!(Assets::destroy_approvals(RuntimeOrigin::signed(1), asset_id));
+		assert_ok!(Assets::finish_destroy(RuntimeOrigin::signed(1), asset_id));
 
 		assert_eq!(Balances::reserved_balance(&1), 0);
 
-		assert!(Asset::<Test>::get(0).unwrap().status == AssetStatus::Destroyed);
-		assert!(!Metadata::<Test>::contains_key(0));
+		assert!(Asset::<Test>::get(asset_id).unwrap().status == AssetStatus::Destroyed);
+		assert!(!Metadata::<Test>::contains_key(asset_id));
 		assert_eq!(Account::<Test>::iter_prefix(0).count(), 0);
 	});
 }
@@ -559,9 +563,11 @@ fn burning_asset_balance_with_positive_balance_should_work() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Assets::do_force_create(0, 1, true, 1));
 		assert_ok!(Assets::do_mint(0, &1, 100, Some(1)));
+		assert_eq!(Assets::total_historical_supply(0, System::block_number()), 100);
 		assert_eq!(Assets::balance(0, 1), 100);
 		let flags = DebitFlags { keep_alive: false, best_effort: true };
 		let _ = Assets::do_burn(0, &1, u64::MAX, Some(1), flags);
+		assert_eq!(Assets::total_historical_supply(0, System::block_number()), 0);
 		assert_eq!(Assets::balance(0, 1), 0);
 	});
 }
@@ -799,5 +805,55 @@ fn reserving_and_unreserving_should_work() {
 		// check undoing reservation worked
 		assert_eq!(Assets::balance(999, 1), 100);
 		assert_eq!(Assets::reserved(999, 1), 0);
+	})
+}
+
+fn run_to_block(n: u64) {
+	use frame_support::traits::{OnFinalize, OnInitialize};
+	while System::block_number() < n {
+		let mut block = System::block_number();
+		Assets::on_finalize(block);
+		System::on_finalize(block);
+		System::reset_events();
+		block += 1;
+		System::set_block_number(block);
+		System::on_initialize(block);
+		Assets::on_initialize(block);
+	}
+}
+
+#[test]
+fn supply_history_query_historic_blocks_should_work() {
+	new_test_ext().execute_with(|| {
+		let asset_id = 95;
+		let account_id = 32;
+		let account_id2 = 974;
+		let amount = 345;
+		let burn_amount = 127;
+		let start_block = System::block_number();
+		let mut block = start_block;
+		assert_eq!(Assets::total_historical_supply(asset_id, block), 0);
+		assert_ok!(Assets::do_force_create(asset_id, account_id, true, 1));
+		assert_ok!(Assets::do_mint(asset_id, &account_id, amount, None));
+		assert_eq!(Assets::total_historical_supply(asset_id, block), amount);
+		assert_ok!(Assets::do_mint(asset_id, &account_id2, amount, None));
+		assert_eq!(Assets::total_historical_supply(asset_id, block), 2 * amount);
+		block += 5;
+		run_to_block(block);
+		assert_eq!(Assets::total_historical_supply(asset_id, block - 3), 2 * amount);
+		assert_eq!(Assets::total_historical_supply(asset_id, start_block), 2 * amount);
+		let flags = DebitFlags { keep_alive: false, best_effort: false};
+		assert_ok!(Assets::do_burn(asset_id, &account_id2, burn_amount, None, flags));
+		assert_eq!(Assets::total_historical_supply(asset_id, block - 3), 2 * amount);
+		assert_eq!(Assets::total_historical_supply(asset_id, block), 2 * amount - burn_amount);
+		assert_eq!(Assets::total_historical_supply(asset_id, start_block), 2 * amount);
+		block += 19;
+		run_to_block(block);
+		assert_eq!(Assets::total_historical_supply(asset_id, block - 3), 2 * amount - burn_amount);
+		assert_eq!(Assets::total_historical_supply(asset_id, start_block), 2 * amount);
+		assert_ok!(Assets::do_burn(asset_id, &account_id2, burn_amount, None, flags));
+		assert_eq!(Assets::total_historical_supply(asset_id, block - 3), 2 * amount - burn_amount);
+		assert_eq!(Assets::total_historical_supply(asset_id, block), 2 * amount - 2 * burn_amount);
+		assert_eq!(Assets::total_historical_supply(asset_id, start_block), 2 * amount);
 	})
 }

--- a/pallets/dao-assets/src/types.rs
+++ b/pallets/dao-assets/src/types.rs
@@ -7,10 +7,19 @@ use frame_support::{
 };
 use sp_runtime::{traits::Convert, FixedPointNumber, FixedPointOperand, FixedU128};
 
-pub(super) type DepositBalanceOf<T, I = ()> =
-	<<T as Config<I>>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
-pub(super) type AssetAccountOf<T, I> =
-	AssetAccount<<T as Config<I>>::Balance, DepositBalanceOf<T, I>>;
+// Type alias for `frame_system`'s account id.
+type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+// This pallet's asset id and balance type.
+type AssetIdOf<T, I> = <T as Config<I>>::AssetId;
+pub type AssetBalanceOf<T, I> = <T as Config<I>>::Balance;
+// Generic fungible balance type.
+pub type BalanceOf<F, T> = <F as fungible::Inspect<AccountIdOf<T>>>::Balance;
+// The deposit balance type
+pub type DepositBalanceOf<T, I> = <<T as Config<I>>::Currency as Currency<AccountIdOf<T>>>::Balance;
+// The account data for an asset
+pub type AssetAccountOf<T, I> = AssetAccount<AssetBalanceOf<T, I>, DepositBalanceOf<T, I>>;
+pub type AssetDetailsOf<T, I> =
+	AssetDetails<AssetBalanceOf<T, I>, AccountIdOf<T>, DepositBalanceOf<T, I>>;
 
 /// AssetStatus holds the current state of the asset. It could either be Live and available for use,
 /// or in a Destroying state.
@@ -155,14 +164,6 @@ pub enum ConversionError {
 	/// converted.
 	AssetNotSufficient,
 }
-
-// Type alias for `frame_system`'s account id.
-type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
-// This pallet's asset id and balance type.
-type AssetIdOf<T, I> = <T as Config<I>>::AssetId;
-type AssetBalanceOf<T, I> = <T as Config<I>>::Balance;
-// Generic fungible balance type.
-type BalanceOf<F, T> = <F as fungible::Inspect<AccountIdOf<T>>>::Balance;
 
 /// Converts a balance value into an asset balance based on the ratio between the fungible's
 /// minimum balance and the minimum asset balance.


### PR DESCRIPTION
This introduces a SupplyHistory Vec in a StorageMap which needs no destroy functionality and includes binary_search (using partition_point) with tests.

One potential issue is that there is no TryAppend impl for Vec, which means that to this code reads the entire Vec from storage, pushes one value onto it and writes the entire Vec back to the StorageMap. So as the History grows, the amount of data read and written grows linearly.
