### PR TITLE
Rm second generic arg from config

### DIFF
--- a/pallets/dao-assets/src/benchmarking.rs
+++ b/pallets/dao-assets/src/benchmarking.rs
@@ -3,101 +3,87 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
-use frame_benchmarking::{
-	account, benchmarks_instance_pallet, whitelist_account, whitelisted_caller,
-};
-use frame_support::{
-	dispatch::UnfilteredDispatchable,
-	traits::{EnsureOrigin, Get},
-};
+use frame_benchmarking::{account, benchmarks, whitelist_account, whitelisted_caller};
+use frame_support::traits::{EnsureOrigin, Get};
 use frame_system::RawOrigin as SystemOrigin;
 use sp_runtime::traits::Bounded;
-use sp_std::prelude::*;
 
 use crate::Pallet as Assets;
 
 const SEED: u32 = 0;
 
-fn default_asset_id<T: Config<I>, I: 'static>() -> T::AssetIdParameter {
+fn default_asset_id<T: Config>() -> T::AssetIdParameter {
 	T::BenchmarkHelper::create_asset_id_parameter(0)
 }
 
-fn create_default_asset<T: Config<I>, I: 'static>(
+fn create_default_asset<T: Config>(
 	is_sufficient: bool,
-) -> (T::AssetIdParameter, T::AccountId, AccountIdLookupOf<T>) {
-	let asset_id = default_asset_id::<T, I>();
+) -> (T::AssetIdParameter, T::AccountId) {
+	let asset_id = default_asset_id::<T>();
 	let caller: T::AccountId = whitelisted_caller();
-	let caller_lookup = T::Lookup::unlookup(caller.clone());
-	let root = SystemOrigin::Root.into();
-	assert!(Assets::<T, I>::force_create(
-		root,
-		asset_id,
-		caller_lookup.clone(),
+	assert!(Assets::<T>::do_force_create(
+		asset_id.into(),
+		caller,
 		is_sufficient,
 		1u32.into(),
 	)
 	.is_ok());
-	(asset_id, caller, caller_lookup)
+	(asset_id, caller)
 }
 
-fn create_default_minted_asset<T: Config<I>, I: 'static>(
+fn create_default_minted_asset<T: Config>(
 	is_sufficient: bool,
 	amount: T::Balance,
-) -> (T::AssetIdParameter, T::AccountId, AccountIdLookupOf<T>) {
-	let (asset_id, caller, caller_lookup) = create_default_asset::<T, I>(is_sufficient);
+) -> (T::AssetIdParameter, T::AccountId) {
+	let (asset_id, caller) = create_default_asset::<T>(is_sufficient);
 	if !is_sufficient {
 		T::Currency::make_free_balance_be(&caller, T::Currency::minimum_balance());
 	}
-	assert!(Assets::<T, I>::mint(
-		SystemOrigin::Signed(caller.clone()).into(),
-		asset_id,
-		caller_lookup.clone(),
+	assert!(Assets::<T>::do_mint(
+		asset_id.into(),
+		&caller,
 		amount,
+		Some(caller)
 	)
 	.is_ok());
-	(asset_id, caller, caller_lookup)
+	(asset_id, caller)
 }
 
-fn swap_is_sufficient<T: Config<I>, I: 'static>(s: &mut bool) {
-	let asset_id = default_asset_id::<T, I>();
-	Asset::<T, I>::mutate(&asset_id.into(), |maybe_a| {
+fn swap_is_sufficient<T: Config>(s: &mut bool) {
+	let asset_id = default_asset_id::<T>();
+	Asset::<T>::mutate(&asset_id.into(), |maybe_a| {
 		if let Some(ref mut a) = maybe_a {
 			sp_std::mem::swap(s, &mut a.is_sufficient)
 		}
 	});
 }
 
-fn add_sufficients<T: Config<I>, I: 'static>(minter: T::AccountId, n: u32) {
-	let asset_id = default_asset_id::<T, I>();
+fn add_sufficients<T: Config>(minter: T::AccountId, n: u32) {
+	let asset_id = default_asset_id::<T>();
 	let origin = SystemOrigin::Signed(minter);
 	let mut s = true;
-	swap_is_sufficient::<T, I>(&mut s);
+	swap_is_sufficient::<T>(&mut s);
 	for i in 0..n {
 		let target = account("sufficient", i, SEED);
 		let target_lookup = T::Lookup::unlookup(target);
-		assert!(Assets::<T, I>::mint(
-			origin.clone().into(),
-			asset_id,
-			target_lookup,
-			100u32.into()
-		)
-		.is_ok());
+		assert!(Assets::<T>::mint(origin.clone().into(), asset_id, target_lookup, 100u32.into())
+			.is_ok());
 	}
-	swap_is_sufficient::<T, I>(&mut s);
+	swap_is_sufficient::<T>(&mut s);
 }
 
-fn add_approvals<T: Config<I>, I: 'static>(minter: T::AccountId, n: u32) {
-	let asset_id = default_asset_id::<T, I>();
+fn add_approvals<T: Config>(minter: T::AccountId, n: u32) {
+	let asset_id = default_asset_id::<T>();
 	T::Currency::deposit_creating(&minter, T::ApprovalDeposit::get() * n.into());
 	let minter_lookup = T::Lookup::unlookup(minter.clone());
 	let origin = SystemOrigin::Signed(minter);
-	Assets::<T, I>::mint(origin.clone().into(), asset_id, minter_lookup, (100 * (n + 1)).into())
+	Assets::<T>::mint(origin.clone().into(), asset_id, minter_lookup, (100 * (n + 1)).into())
 		.unwrap();
 	for i in 0..n {
 		let target = account("approval", i, SEED);
 		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
 		let target_lookup = T::Lookup::unlookup(target);
-		Assets::<T, I>::approve_transfer(
+		Assets::<T>::approve_transfer(
 			origin.clone().into(),
 			asset_id,
 			target_lookup,
@@ -107,50 +93,50 @@ fn add_approvals<T: Config<I>, I: 'static>(minter: T::AccountId, n: u32) {
 	}
 }
 
-fn assert_last_event<T: Config<I>, I: 'static>(generic_event: <T as Config<I>>::RuntimeEvent) {
+fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
-fn assert_event<T: Config<I>, I: 'static>(generic_event: <T as Config<I>>::RuntimeEvent) {
+fn assert_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
 }
 
-benchmarks_instance_pallet! {
+benchmarks! {
 	create {
-		let asset_id = default_asset_id::<T, I>();
+		let asset_id = default_asset_id::<T>();
 		let origin = T::CreateOrigin::successful_origin(&asset_id.into());
 		let caller = T::CreateOrigin::ensure_origin(origin, &asset_id.into()).unwrap();
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T>::max_value());
 	}: _(SystemOrigin::Signed(caller.clone()), asset_id, caller_lookup, 1u32.into())
 	verify {
-		assert_last_event::<T, I>(Event::Created { asset_id: asset_id.into(), creator: caller.clone(), owner: caller }.into());
+		assert_last_event::<T>(Event::Created { asset_id: asset_id.into(), creator: caller.clone(), owner: caller }.into());
 	}
 
 	force_create {
-		let asset_id = default_asset_id::<T, I>();
+		let asset_id = default_asset_id::<T>();
 		let caller: T::AccountId = whitelisted_caller();
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 	}: _(SystemOrigin::Root, asset_id, caller_lookup, true, 1u32.into())
 	verify {
-		assert_last_event::<T, I>(Event::ForceCreated { asset_id: asset_id.into(), owner: caller }.into());
+		assert_last_event::<T>(Event::ForceCreated { asset_id: asset_id.into(), owner: caller }.into());
 	}
 
 	start_destroy {
-		let (asset_id, caller, caller_lookup) = create_default_minted_asset::<T, I>(true, 100u32.into());
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, 100u32.into());
 	}:_(SystemOrigin::Signed(caller), asset_id)
 	verify {
-		assert_last_event::<T, I>(Event::DestructionStarted { asset_id: asset_id.into() }.into());
+		assert_last_event::<T>(Event::DestructionStarted { asset_id: asset_id.into() }.into());
 	}
 
 	destroy_accounts {
 		let c in 0 .. T::RemoveItemsLimit::get();
-		let (asset_id, caller, _) = create_default_asset::<T, I>(true);
-		add_sufficients::<T, I>(caller.clone(), c);
-		Assets::<T,I>::start_destroy(SystemOrigin::Signed(caller.clone()).into(), asset_id)?;
+		let (asset_id, caller) = create_default_asset::<T>(true);
+		add_sufficients::<T>(caller.clone(), c);
+		Assets::<T>::start_destroy(SystemOrigin::Signed(caller.clone()).into(), asset_id)?;
 	}:_(SystemOrigin::Signed(caller), asset_id)
 	verify {
-		assert_last_event::<T, I>(Event::AccountsDestroyed {
+		assert_last_event::<T>(Event::AccountsDestroyed {
 			asset_id: asset_id.into(),
 			accounts_destroyed: c,
 			accounts_remaining: 0,
@@ -159,12 +145,12 @@ benchmarks_instance_pallet! {
 
 	destroy_approvals {
 		let a in 0 .. T::RemoveItemsLimit::get();
-		let (asset_id, caller, _) = create_default_minted_asset::<T, I>(true, 100u32.into());
-		add_approvals::<T, I>(caller.clone(), a);
-		Assets::<T,I>::start_destroy(SystemOrigin::Signed(caller.clone()).into(), asset_id)?;
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, 100u32.into());
+		add_approvals::<T>(caller.clone(), a);
+		Assets::<T>::start_destroy(SystemOrigin::Signed(caller.clone()).into(), asset_id)?;
 	}:_(SystemOrigin::Signed(caller), asset_id)
 	verify {
-		assert_last_event::<T, I>(Event::ApprovalsDestroyed {
+		assert_last_event::<T>(Event::ApprovalsDestroyed {
 			asset_id: asset_id.into(),
 			approvals_destroyed: a,
 			approvals_remaining: 0,
@@ -172,82 +158,82 @@ benchmarks_instance_pallet! {
 	}
 
 	finish_destroy {
-		let (asset_id, caller, caller_lookup) = create_default_asset::<T, I>(true);
-		Assets::<T,I>::start_destroy(SystemOrigin::Signed(caller.clone()).into(), asset_id)?;
+		let (asset_id, caller) = create_default_asset::<T>(true);
+		Assets::<T>::start_destroy(SystemOrigin::Signed(caller.clone()).into(), asset_id)?;
 	}:_(SystemOrigin::Signed(caller), asset_id)
 	verify {
-		assert_last_event::<T, I>(Event::Destroyed {
+		assert_last_event::<T>(Event::Destroyed {
 			asset_id: asset_id.into(),
 		}.into()
 		);
 	}
 
 	mint {
-		let (asset_id, caller, caller_lookup) = create_default_asset::<T, I>(true);
+		let (asset_id, caller) = create_default_asset::<T>(true);
 		let amount = T::Balance::from(100u32);
-	}: _(SystemOrigin::Signed(caller.clone()), asset_id, caller_lookup, amount)
+	}: _(SystemOrigin::Signed(caller.clone()), asset_id, amount)
 	verify {
-		assert_last_event::<T, I>(Event::Issued { asset_id: asset_id.into(), owner: caller, total_supply: amount }.into());
+		assert_last_event::<T>(Event::Issued { asset_id: asset_id.into(), owner: caller, total_supply: amount }.into());
 	}
 
 	burn {
 		let amount = T::Balance::from(100u32);
-		let (asset_id, caller, caller_lookup) = create_default_minted_asset::<T, I>(true, amount);
-	}: _(SystemOrigin::Signed(caller.clone()), asset_id, caller_lookup, amount)
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, amount);
+	}: _(SystemOrigin::Signed(caller.clone()), asset_id, amount)
 	verify {
-		assert_last_event::<T, I>(Event::Burned { asset_id: asset_id.into(), owner: caller, balance: amount }.into());
+		assert_last_event::<T>(Event::Burned { asset_id: asset_id.into(), owner: caller, balance: amount }.into());
 	}
 
 	transfer {
 		let amount = T::Balance::from(100u32);
-		let (asset_id, caller, caller_lookup) = create_default_minted_asset::<T, I>(true, amount);
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, amount);
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 	}: _(SystemOrigin::Signed(caller.clone()), asset_id, target_lookup, amount)
 	verify {
-		assert_last_event::<T, I>(Event::Transferred { asset_id: asset_id.into(), from: caller, to: target, amount }.into());
+		assert_last_event::<T>(Event::Transferred { asset_id: asset_id.into(), from: caller, to: target, amount }.into());
 	}
 
 	transfer_keep_alive {
 		let mint_amount = T::Balance::from(200u32);
 		let amount = T::Balance::from(100u32);
-		let (asset_id, caller, caller_lookup) = create_default_minted_asset::<T, I>(true, mint_amount);
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, mint_amount);
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 	}: _(SystemOrigin::Signed(caller.clone()), asset_id, target_lookup, amount)
 	verify {
 		assert!(frame_system::Pallet::<T>::account_exists(&caller));
-		assert_last_event::<T, I>(Event::Transferred { asset_id: asset_id.into(), from: caller, to: target, amount }.into());
+		assert_last_event::<T>(Event::Transferred { asset_id: asset_id.into(), from: caller, to: target, amount }.into());
 	}
 
 	force_transfer {
 		let amount = T::Balance::from(100u32);
-		let (asset_id, caller, caller_lookup) = create_default_minted_asset::<T, I>(true, amount);
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, amount);
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
-	}: _(SystemOrigin::Signed(caller.clone()), asset_id, caller_lookup, target_lookup, amount)
+	}: _(SystemOrigin::Signed(caller.clone()), asset_id, target_lookup, amount)
 	verify {
-		assert_last_event::<T, I>(
+		assert_last_event::<T>(
 			Event::Transferred { asset_id: asset_id.into(), from: caller, to: target, amount }.into()
 		);
 	}
 
 	transfer_ownership {
-		let (asset_id, caller, _) = create_default_asset::<T, I>(true);
+		let (asset_id, caller) = create_default_asset::<T>(true);
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
 	}: _(SystemOrigin::Signed(caller), asset_id, target_lookup)
 	verify {
-		assert_last_event::<T, I>(Event::OwnerChanged { asset_id: asset_id.into(), owner: target }.into());
+		assert_last_event::<T>(Event::OwnerChanged { asset_id: asset_id.into(), owner: target }.into());
 	}
 
 	set_team {
-		let (asset_id, caller, _) = create_default_asset::<T, I>(true);
+		let (asset_id, caller) = create_default_asset::<T>(true);
 		let target0 = T::Lookup::unlookup(account("target", 0, SEED));
 		let target1 = T::Lookup::unlookup(account("target", 1, SEED));
 	}: _(SystemOrigin::Signed(caller), asset_id, target0, target1)
 	verify {
-		assert_last_event::<T, I>(Event::TeamChanged {
+		assert_last_event::<T>(Event::TeamChanged {
 			asset_id: asset_id.into(),
 			issuer: account("target", 0, SEED),
 			admin: account("target", 1, SEED),
@@ -262,22 +248,22 @@ benchmarks_instance_pallet! {
 		let symbol = vec![0u8; s as usize];
 		let decimals = 12;
 
-		let (asset_id, caller, _) = create_default_asset::<T, I>(true);
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		let (asset_id, caller) = create_default_asset::<T>(true);
+		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T>::max_value());
 	}: _(SystemOrigin::Signed(caller), asset_id, name.clone(), symbol.clone(), decimals)
 	verify {
-		assert_last_event::<T, I>(Event::MetadataSet { asset_id: asset_id.into(), name, symbol, decimals, is_frozen: false }.into());
+		assert_last_event::<T>(Event::MetadataSet { asset_id: asset_id.into(), name, symbol, decimals }.into());
 	}
 
 	clear_metadata {
-		let (asset_id, caller, _) = create_default_asset::<T, I>(true);
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		let (asset_id, caller) = create_default_asset::<T>(true);
+		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T>::max_value());
 		let dummy = vec![0u8; T::StringLimit::get() as usize];
 		let origin = SystemOrigin::Signed(caller.clone()).into();
-		Assets::<T, I>::set_metadata(origin, asset_id, dummy.clone(), dummy, 12)?;
+		Assets::<T>::set_metadata(origin, asset_id, dummy.clone(), dummy, 12)?;
 	}: _(SystemOrigin::Signed(caller), asset_id)
 	verify {
-		assert_last_event::<T, I>(Event::MetadataCleared { asset_id: asset_id.into() }.into());
+		assert_last_event::<T>(Event::MetadataCleared { asset_id: asset_id.into() }.into());
 	}
 
 	force_set_metadata {
@@ -288,109 +274,92 @@ benchmarks_instance_pallet! {
 		let symbol = vec![0u8; s as usize];
 		let decimals = 12;
 
-		let (asset_id, _, _) = create_default_asset::<T, I>(true);
+		let (asset_id, _) = create_default_asset::<T>(true);
 
 		let origin = T::ForceOrigin::successful_origin();
-		let call = Call::<T, I>::force_set_metadata {
+		let call = Call::<T>::force_set_metadata {
 			id: asset_id,
 			name: name.clone(),
 			symbol: symbol.clone(),
 			decimals,
-			is_frozen: false,
 		};
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
-		assert_last_event::<T, I>(Event::MetadataSet { asset_id: asset_id.into(), name, symbol, decimals, is_frozen: false }.into());
+		assert_last_event::<T>(Event::MetadataSet { asset_id: asset_id.into(), name, symbol, decimals }.into());
 	}
 
 	force_clear_metadata {
-		let (asset_id, caller, _) = create_default_asset::<T, I>(true);
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		let (asset_id, caller) = create_default_asset::<T>(true);
+		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T>::max_value());
 		let dummy = vec![0u8; T::StringLimit::get() as usize];
 		let origin = SystemOrigin::Signed(caller).into();
-		Assets::<T, I>::set_metadata(origin, asset_id, dummy.clone(), dummy, 12)?;
+		Assets::<T>::set_metadata(origin, asset_id, dummy.clone(), dummy, 12)?;
 
 		let origin = T::ForceOrigin::successful_origin();
-		let call = Call::<T, I>::force_clear_metadata { id: asset_id };
+		let call = Call::<T>::force_clear_metadata { id: asset_id };
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
-		assert_last_event::<T, I>(Event::MetadataCleared { asset_id: asset_id.into() }.into());
-	}
-
-	force_asset_status {
-		let (asset_id, caller, caller_lookup) = create_default_asset::<T, I>(true);
-
-		let origin = T::ForceOrigin::successful_origin();
-		let call = Call::<T, I>::force_asset_status {
-			id: asset_id,
-			owner: caller_lookup.clone(),
-			issuer: caller_lookup.clone(),
-			admin: caller_lookup,
-			min_balance: 100u32.into(),
-			is_sufficient: true,
-		};
-	}: { call.dispatch_bypass_filter(origin)? }
-	verify {
-		assert_last_event::<T, I>(Event::AssetStatusChanged { asset_id: asset_id.into() }.into());
+		assert_last_event::<T>(Event::MetadataCleared { asset_id: asset_id.into() }.into());
 	}
 
 	approve_transfer {
-		let (asset_id, caller, _) = create_default_minted_asset::<T, I>(true, 100u32.into());
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, 100u32.into());
+		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T>::max_value());
 
 		let delegate: T::AccountId = account("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 	}: _(SystemOrigin::Signed(caller.clone()), asset_id, delegate_lookup, amount)
 	verify {
-		assert_last_event::<T, I>(Event::ApprovedTransfer { asset_id: asset_id.into(), source: caller, delegate, amount }.into());
+		assert_last_event::<T>(Event::ApprovedTransfer { asset_id: asset_id.into(), source: caller, delegate, amount }.into());
 	}
 
 	transfer_approved {
-		let (asset_id, owner, owner_lookup) = create_default_minted_asset::<T, I>(true, 100u32.into());
-		T::Currency::make_free_balance_be(&owner, DepositBalanceOf::<T, I>::max_value());
+		let (asset_id, owner) = create_default_minted_asset::<T>(true, 100u32.into());
+		let owner_lookup = T::Lookup::unlookup(owner.clone());
+		T::Currency::make_free_balance_be(&owner, DepositBalanceOf::<T>::max_value());
 
 		let delegate: T::AccountId = account("delegate", 0, SEED);
 		whitelist_account!(delegate);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(owner.clone()).into();
-		Assets::<T, I>::approve_transfer(origin, asset_id, delegate_lookup, amount)?;
+		Assets::<T>::approve_transfer(origin, asset_id, delegate_lookup, amount)?;
 
 		let dest: T::AccountId = account("dest", 0, SEED);
 		let dest_lookup = T::Lookup::unlookup(dest.clone());
 	}: _(SystemOrigin::Signed(delegate.clone()), asset_id, owner_lookup, dest_lookup, amount)
 	verify {
 		assert!(T::Currency::reserved_balance(&owner).is_zero());
-		assert_event::<T, I>(Event::Transferred { asset_id: asset_id.into(), from: owner, to: dest, amount }.into());
+		assert_event::<T>(Event::Transferred { asset_id: asset_id.into(), from: owner, to: dest, amount }.into());
 	}
 
 	cancel_approval {
-		let (asset_id, caller, _) = create_default_minted_asset::<T, I>(true, 100u32.into());
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, 100u32.into());
+		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T>::max_value());
 
 		let delegate: T::AccountId = account("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(caller.clone()).into();
-		Assets::<T, I>::approve_transfer(origin, asset_id, delegate_lookup.clone(), amount)?;
+		Assets::<T>::approve_transfer(origin, asset_id, delegate_lookup.clone(), amount)?;
 	}: _(SystemOrigin::Signed(caller.clone()), asset_id, delegate_lookup)
 	verify {
-		assert_last_event::<T, I>(Event::ApprovalCancelled { asset_id: asset_id.into(), owner: caller, delegate }.into());
+		assert_last_event::<T>(Event::ApprovalCancelled { asset_id: asset_id.into(), owner: caller, delegate }.into());
 	}
 
 	force_cancel_approval {
-		let (asset_id, caller, caller_lookup) = create_default_minted_asset::<T, I>(true, 100u32.into());
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		let (asset_id, caller) = create_default_minted_asset::<T>(true, 100u32.into());
+		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T>::max_value());
 
 		let delegate: T::AccountId = account("delegate", 0, SEED);
 		let delegate_lookup = T::Lookup::unlookup(delegate.clone());
 		let amount = 100u32.into();
 		let origin = SystemOrigin::Signed(caller.clone()).into();
-		Assets::<T, I>::approve_transfer(origin, asset_id, delegate_lookup.clone(), amount)?;
-	}: _(SystemOrigin::Signed(caller.clone()), asset_id, caller_lookup, delegate_lookup)
+		Assets::<T>::approve_transfer(origin, asset_id, delegate_lookup.clone(), amount)?;
+	}: _(SystemOrigin::Signed(caller.clone()), asset_id, delegate_lookup)
 	verify {
-		assert_last_event::<T, I>(Event::ApprovalCancelled { asset_id: asset_id.into(), owner: caller, delegate }.into());
+		assert_last_event::<T>(Event::ApprovalCancelled { asset_id: asset_id.into(), owner: caller, delegate }.into());
 	}
 
 	impl_benchmark_test_suite!(Assets, crate::mock::new_test_ext(), crate::mock::Test)

--- a/pallets/dao-assets/src/functions.rs
+++ b/pallets/dao-assets/src/functions.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 use frame_support::{traits::Get, BoundedVec};
-use frame_system::pallet_prelude::BlockNumberFor;
 use sp_std::borrow::Borrow;
 
 #[must_use]
@@ -22,6 +21,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Self::maybe_balance(id, who).unwrap_or_default()
 	}
 
+	/// Get the asset `id` total (including reserved) balance of `who`, or zero if the asset-account doesn't exist.
+	pub fn total_balance(id: T::AssetId, who: impl Borrow<T::AccountId>) -> T::Balance {
+		Self::maybe_total_balance(id, who).unwrap_or_default()
+	}
+
 	/// Get the asset `id` reserved balance of `who`, or zero if the asset-account doesn't exist.
 	pub fn reserved(id: T::AssetId, who: impl Borrow<T::AccountId>) -> T::Balance {
 		Self::maybe_reserved(id, who).unwrap_or_default()
@@ -30,6 +34,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Get the asset `id` free balance of `who` if the asset-account exists.
 	pub fn maybe_balance(id: T::AssetId, who: impl Borrow<T::AccountId>) -> Option<T::Balance> {
 		Account::<T, I>::get(id, who.borrow()).map(|a| a.balance)
+	}
+
+	/// Get the asset `id` total (including reserved) balance of `who` if the asset-account exists.
+	pub fn maybe_total_balance(id: T::AssetId, who: impl Borrow<T::AccountId>) -> Option<T::Balance> {
+		Account::<T, I>::get(id, who.borrow()).map(|a| a.balance + a.reserved)
 	}
 
 	/// Get the asset `id` reserved balance of `who` if the asset-account exists.

--- a/pallets/dao-assets/src/impl_fungibles.rs
+++ b/pallets/dao-assets/src/impl_fungibles.rs
@@ -2,20 +2,20 @@
 
 use super::*;
 
-impl<T: Config<I>, I: 'static> fungibles::Inspect<<T as SystemConfig>::AccountId> for Pallet<T, I> {
+impl<T: Config> fungibles::Inspect<<T as SystemConfig>::AccountId> for Pallet<T> {
 	type AssetId = T::AssetId;
 	type Balance = T::Balance;
 
 	fn total_issuance(asset: Self::AssetId) -> Self::Balance {
-		Asset::<T, I>::get(asset).map(|x| x.supply).unwrap_or_else(Zero::zero)
+		Asset::<T>::get(asset).map(|x| x.supply).unwrap_or_else(Zero::zero)
 	}
 
 	fn minimum_balance(asset: Self::AssetId) -> Self::Balance {
-		Asset::<T, I>::get(asset).map(|x| x.min_balance).unwrap_or_else(Zero::zero)
+		Asset::<T>::get(asset).map(|x| x.min_balance).unwrap_or_else(Zero::zero)
 	}
 
 	fn balance(asset: Self::AssetId, who: &<T as SystemConfig>::AccountId) -> Self::Balance {
-		Pallet::<T, I>::balance(asset, who)
+		Pallet::<T>::balance(asset, who)
 	}
 
 	fn reducible_balance(
@@ -23,7 +23,7 @@ impl<T: Config<I>, I: 'static> fungibles::Inspect<<T as SystemConfig>::AccountId
 		who: &<T as SystemConfig>::AccountId,
 		keep_alive: bool,
 	) -> Self::Balance {
-		Pallet::<T, I>::reducible_balance(asset, who, keep_alive).unwrap_or(Zero::zero())
+		Pallet::<T>::reducible_balance(asset, who, keep_alive).unwrap_or(Zero::zero())
 	}
 
 	fn can_deposit(
@@ -32,7 +32,7 @@ impl<T: Config<I>, I: 'static> fungibles::Inspect<<T as SystemConfig>::AccountId
 		amount: Self::Balance,
 		mint: bool,
 	) -> DepositConsequence {
-		Pallet::<T, I>::can_increase(asset, who, amount, mint)
+		Pallet::<T>::can_increase(asset, who, amount, mint)
 	}
 
 	fn can_withdraw(
@@ -40,34 +40,32 @@ impl<T: Config<I>, I: 'static> fungibles::Inspect<<T as SystemConfig>::AccountId
 		who: &<T as SystemConfig>::AccountId,
 		amount: Self::Balance,
 	) -> WithdrawConsequence<Self::Balance> {
-		Pallet::<T, I>::can_decrease(asset, who, amount, false)
+		Pallet::<T>::can_decrease(asset, who, amount, false)
 	}
 
 	fn asset_exists(asset: Self::AssetId) -> bool {
-		Asset::<T, I>::contains_key(asset)
+		Asset::<T>::contains_key(asset)
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::InspectMetadata<<T as SystemConfig>::AccountId>
-	for Pallet<T, I>
-{
+impl<T: Config> fungibles::InspectMetadata<<T as SystemConfig>::AccountId> for Pallet<T> {
 	/// Return the name of an asset.
 	fn name(asset: &Self::AssetId) -> Vec<u8> {
-		Metadata::<T, I>::get(asset).name.to_vec()
+		Metadata::<T>::get(asset).name.to_vec()
 	}
 
 	/// Return the symbol of an asset.
 	fn symbol(asset: &Self::AssetId) -> Vec<u8> {
-		Metadata::<T, I>::get(asset).symbol.to_vec()
+		Metadata::<T>::get(asset).symbol.to_vec()
 	}
 
 	/// Return the decimals of an asset.
 	fn decimals(asset: &Self::AssetId) -> u8 {
-		Metadata::<T, I>::get(asset).decimals
+		Metadata::<T>::get(asset).decimals
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::Mutate<<T as SystemConfig>::AccountId> for Pallet<T, I> {
+impl<T: Config> fungibles::Mutate<<T as SystemConfig>::AccountId> for Pallet<T> {
 	fn mint_into(
 		asset: Self::AssetId,
 		who: &<T as SystemConfig>::AccountId,
@@ -95,7 +93,7 @@ impl<T: Config<I>, I: 'static> fungibles::Mutate<<T as SystemConfig>::AccountId>
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::Transfer<T::AccountId> for Pallet<T, I> {
+impl<T: Config> fungibles::Transfer<T::AccountId> for Pallet<T> {
 	fn transfer(
 		asset: Self::AssetId,
 		source: &T::AccountId,
@@ -108,12 +106,12 @@ impl<T: Config<I>, I: 'static> fungibles::Transfer<T::AccountId> for Pallet<T, I
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::Unbalanced<T::AccountId> for Pallet<T, I> {
+impl<T: Config> fungibles::Unbalanced<T::AccountId> for Pallet<T> {
 	fn set_balance(_: Self::AssetId, _: &T::AccountId, _: Self::Balance) -> DispatchResult {
 		unreachable!("set_balance is not used if other functions are impl'd");
 	}
 	fn set_total_issuance(id: T::AssetId, amount: Self::Balance) {
-		Asset::<T, I>::mutate_exists(id, |maybe_asset| {
+		Asset::<T>::mutate_exists(id, |maybe_asset| {
 			if let Some(ref mut asset) = maybe_asset {
 				asset.supply = amount
 			}
@@ -155,7 +153,7 @@ impl<T: Config<I>, I: 'static> fungibles::Unbalanced<T::AccountId> for Pallet<T,
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::Create<T::AccountId> for Pallet<T, I> {
+impl<T: Config> fungibles::Create<T::AccountId> for Pallet<T> {
 	fn create(
 		id: T::AssetId,
 		admin: T::AccountId,
@@ -166,7 +164,7 @@ impl<T: Config<I>, I: 'static> fungibles::Create<T::AccountId> for Pallet<T, I> 
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::Destroy<T::AccountId> for Pallet<T, I> {
+impl<T: Config> fungibles::Destroy<T::AccountId> for Pallet<T> {
 	fn start_destroy(id: T::AssetId, maybe_check_owner: Option<T::AccountId>) -> DispatchResult {
 		Self::do_start_destroy(id, maybe_check_owner)
 	}
@@ -184,25 +182,21 @@ impl<T: Config<I>, I: 'static> fungibles::Destroy<T::AccountId> for Pallet<T, I>
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::metadata::Inspect<<T as SystemConfig>::AccountId>
-	for Pallet<T, I>
-{
+impl<T: Config> fungibles::metadata::Inspect<<T as SystemConfig>::AccountId> for Pallet<T> {
 	fn name(asset: T::AssetId) -> Vec<u8> {
-		Metadata::<T, I>::get(asset).name.to_vec()
+		Metadata::<T>::get(asset).name.to_vec()
 	}
 
 	fn symbol(asset: T::AssetId) -> Vec<u8> {
-		Metadata::<T, I>::get(asset).symbol.to_vec()
+		Metadata::<T>::get(asset).symbol.to_vec()
 	}
 
 	fn decimals(asset: T::AssetId) -> u8 {
-		Metadata::<T, I>::get(asset).decimals
+		Metadata::<T>::get(asset).decimals
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::metadata::Mutate<<T as SystemConfig>::AccountId>
-	for Pallet<T, I>
-{
+impl<T: Config> fungibles::metadata::Mutate<<T as SystemConfig>::AccountId> for Pallet<T> {
 	fn set(
 		asset: T::AssetId,
 		from: &<T as SystemConfig>::AccountId,
@@ -214,24 +208,20 @@ impl<T: Config<I>, I: 'static> fungibles::metadata::Mutate<<T as SystemConfig>::
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::approvals::Inspect<<T as SystemConfig>::AccountId>
-	for Pallet<T, I>
-{
+impl<T: Config> fungibles::approvals::Inspect<<T as SystemConfig>::AccountId> for Pallet<T> {
 	// Check the amount approved to be spent by an owner to a delegate
 	fn allowance(
 		asset: T::AssetId,
 		owner: &<T as SystemConfig>::AccountId,
 		delegate: &<T as SystemConfig>::AccountId,
 	) -> T::Balance {
-		Approvals::<T, I>::get((asset, &owner, &delegate))
+		Approvals::<T>::get((asset, &owner, &delegate))
 			.map(|x| x.amount)
 			.unwrap_or_else(Zero::zero)
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::approvals::Mutate<<T as SystemConfig>::AccountId>
-	for Pallet<T, I>
-{
+impl<T: Config> fungibles::approvals::Mutate<<T as SystemConfig>::AccountId> for Pallet<T> {
 	fn approve(
 		asset: T::AssetId,
 		owner: &<T as SystemConfig>::AccountId,
@@ -253,19 +243,17 @@ impl<T: Config<I>, I: 'static> fungibles::approvals::Mutate<<T as SystemConfig>:
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::roles::Inspect<<T as SystemConfig>::AccountId>
-	for Pallet<T, I>
-{
+impl<T: Config> fungibles::roles::Inspect<<T as SystemConfig>::AccountId> for Pallet<T> {
 	fn owner(asset: T::AssetId) -> Option<<T as SystemConfig>::AccountId> {
-		Asset::<T, I>::get(asset).map(|x| x.owner)
+		Asset::<T>::get(asset).map(|x| x.owner)
 	}
 
 	fn issuer(asset: T::AssetId) -> Option<<T as SystemConfig>::AccountId> {
-		Asset::<T, I>::get(asset).map(|x| x.issuer)
+		Asset::<T>::get(asset).map(|x| x.issuer)
 	}
 
 	fn admin(asset: T::AssetId) -> Option<<T as SystemConfig>::AccountId> {
-		Asset::<T, I>::get(asset).map(|x| x.admin)
+		Asset::<T>::get(asset).map(|x| x.admin)
 	}
 
 	fn freezer(_asset: T::AssetId) -> Option<<T as SystemConfig>::AccountId> {
@@ -273,13 +261,13 @@ impl<T: Config<I>, I: 'static> fungibles::roles::Inspect<<T as SystemConfig>::Ac
 	}
 }
 
-impl<T: Config<I>, I: 'static> fungibles::InspectEnumerable<T::AccountId> for Pallet<T, I> {
-	type AssetsIterator = KeyPrefixIterator<<T as Config<I>>::AssetId>;
+impl<T: Config> fungibles::InspectEnumerable<T::AccountId> for Pallet<T> {
+	type AssetsIterator = KeyPrefixIterator<<T as Config>::AssetId>;
 
 	/// Returns an iterator of the assets in existence.
 	///
 	/// NOTE: iterating this list invokes a storage read per item.
 	fn asset_ids() -> Self::AssetsIterator {
-		Asset::<T, I>::iter_keys()
+		Asset::<T>::iter_keys()
 	}
 }

--- a/pallets/dao-core/src/lib.rs
+++ b/pallets/dao-core/src/lib.rs
@@ -27,6 +27,7 @@ pub use frame_support::{
 	weights::Weight,
 };
 
+pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type CurrencyOf<T> = <T as Config>::Currency;
 pub type DepositBalanceOf<T> =
 	<CurrencyOf<T> as Currency<<T as frame_system::Config>::AccountId>>::Balance;
@@ -67,7 +68,9 @@ pub mod pallet {
 		type Currency: ReservableCurrency<Self::AccountId>;
 
 		type AssetId: IsType<<Self as pallet_dao_assets::Config>::AssetId>
+			+ Member
 			+ Parameter
+			+ Copy
 			+ Default
 			+ MaxEncodedLen
 			+ One

--- a/pallets/dao-votes/src/governance_types.rs
+++ b/pallets/dao-votes/src/governance_types.rs
@@ -16,7 +16,7 @@ pub struct Governance<Balance> {
 pub enum Voting {
 	Majority {
 		// how many more ayes than nays there must be for proposal acceptance
-		// thus proposal acceptance requires: ayes >= nays + minimum_majority_pct * token_supply / 256
+		// thus proposal acceptance requires: ayes >= nays + token_supply / 256 * minimum_majority_per_256
 		minimum_majority_per_256: u8,
 	},
 }

--- a/pallets/dao-votes/src/governance_types.rs
+++ b/pallets/dao-votes/src/governance_types.rs
@@ -1,0 +1,22 @@
+use codec::MaxEncodedLen;
+use frame_support::{codec::{Decode, Encode}, RuntimeDebug};
+use scale_info::TypeInfo;
+
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+pub struct Governance<Balance> {
+	// the number of blocks a proposal is open for voting
+	pub proposal_duration: u32,
+	// the token deposit required to create a proposal
+	pub proposal_token_deposit: Balance,
+	// the rules for accepting proposals
+	pub voting: Voting,
+}
+
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+pub enum Voting {
+	Majority {
+		// how many more ayes than nays there must be for proposal acceptance
+		// thus proposal acceptance requires: ayes >= nays + minimum_majority_pct * token_supply / 256
+		minimum_majority_per_256: u8,
+	},
+}

--- a/pallets/dao-votes/src/lib.rs
+++ b/pallets/dao-votes/src/lib.rs
@@ -33,7 +33,7 @@ type ProposalOf<T> = Proposal<
 	pallet_dao_core::MetadataOf<T>,
 >;
 
-type GovernanceOf<T, I = ()> = Governance<AssetBalanceOf<T, I>>;
+type GovernanceOf<T> = Governance<AssetBalanceOf<T>>;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -210,8 +210,8 @@ pub mod pallet {
 				.expect("asset has been issued");
 
 			// count votes
-			let mut votes_for: AssetBalanceOf<T, ()> = Zero::zero();
-			let mut votes_against: AssetBalanceOf<T, ()> = Zero::zero();
+			let mut votes_for: AssetBalanceOf<T> = Zero::zero();
+			let mut votes_against: AssetBalanceOf<T> = Zero::zero();
 			for (account_id, in_favor) in <Votes<T>>::iter_prefix(&proposal_id) {
 				let token_balance = Assets::<T>::total_balance(asset_id.into(), account_id);
 				if in_favor {
@@ -227,7 +227,7 @@ pub mod pallet {
 					if votes_for > votes_against && {
 						let token_supply = Assets::<T>::total_supply(asset_id.into());
 						let required_majority = token_supply /
-							Into::<AssetBalanceOf<T, ()>>::into(256_u32) *
+							Into::<AssetBalanceOf<T>>::into(256_u32) *
 							minimum_majority_per_256.into();
 						// check for the required majority
 						votes_for - votes_against >= required_majority

--- a/pallets/dao-votes/src/types.rs
+++ b/pallets/dao-votes/src/types.rs
@@ -17,17 +17,11 @@ pub struct Proposal<Id, DaoId, AccountId, BlockId, Metadata> {
 	pub status: ProposalStatus,
 }
 
-#[derive(Clone, Encode, Decode, Eq, PartialEq, Default, RuntimeDebug, MaxEncodedLen, TypeInfo)]
-pub struct Vote<AccountId> {
-	pub voter: AccountId,
-	pub aye: bool,
-}
-
-#[derive(Clone, Encode, Decode, Eq, PartialEq, Default, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+#[derive(Clone, Copy, Encode, Decode, Eq, PartialEq, Default, RuntimeDebug, MaxEncodedLen, TypeInfo)]
 pub enum ProposalStatus {
 	#[default]
 	Active,
-	Success,
-	Faulty,
+	Accepted,
 	Rejected,
+	Faulty,
 }

--- a/pallets/dao-votes/src/types.rs
+++ b/pallets/dao-votes/src/types.rs
@@ -1,7 +1,9 @@
 use codec::MaxEncodedLen;
-use frame_support::{traits::ConstU32, BoundedVec, RuntimeDebug};
-
-use frame_support::codec::{Decode, Encode};
+use frame_support::{
+	codec::{Decode, Encode},
+	traits::ConstU32,
+	BoundedVec, RuntimeDebug,
+};
 use scale_info::TypeInfo;
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Default, RuntimeDebug, MaxEncodedLen, TypeInfo)]


### PR DESCRIPTION
Pallet assets is an "instantiable pallet" (https://substrate.recipes/instantiable.html) which basically means you can have multiple copies of it in the same run-time. I don't think we need that for dao-assets, and because the extra generic argument that permeates much of the code is confusing, we are better off without it. 