### PR TITLE
12 add compound like voting to pallet assets

### DIFF
--- a/pallets/dao-assets/src/functions.rs
+++ b/pallets/dao-assets/src/functions.rs
@@ -3,9 +3,10 @@
 use super::*;
 use frame_support::{traits::Get, BoundedVec};
 use frame_system::pallet_prelude::BlockNumberFor;
-use sp_std::borrow::Borrow;
+use sp_std::{borrow::Borrow, fmt::Debug};
 
 #[must_use]
+#[derive(PartialEq)]
 pub(super) enum DeadConsequence {
 	Remove,
 	Keep,
@@ -65,6 +66,27 @@ impl<T: Config> Pallet<T> {
 	/// Result may be None, if the age of the requested block is at or beyond
 	/// the HistoryHorizon and history has been removed.
 	pub fn total_historical_supply(id: T::AssetId, block: BlockNumberFor<T>) -> Option<T::Balance> {
+		Self::search_history(SupplyHistory::<T>::get(id), block)
+	}
+
+	/// Get the total historical balance of an asset `id` at a certain `block` for an account `who`.
+	/// Result may be None, if the age of the requested block is at or beyond
+	/// the HistoryHorizon and history has been removed.
+	pub fn total_historical_balance(
+		id: T::AssetId,
+		who: impl Borrow<T::AccountId>,
+		block: BlockNumberFor<T>,
+	) -> Option<T::Balance> {
+		Self::search_history(AccountHistory::<T>::get(id, who.borrow()), block)
+	}
+
+	/// Search a history for the value at a specific block.
+	/// Result may be None, if the age of the requested block is at or beyond
+	/// the HistoryHorizon and history has been removed.
+	fn search_history<V: Copy + Zero, B: Get<u32>>(
+		history: Option<BoundedBTreeMap<BlockNumberFor<T>, V, B>>,
+		block: BlockNumberFor<T>,
+	) -> Option<V> {
 		let default = || {
 			let current_block = frame_system::Pallet::<T>::block_number();
 			if current_block - block < T::HistoryHorizon::get().into() {
@@ -73,14 +95,32 @@ impl<T: Config> Pallet<T> {
 				None
 			}
 		};
-
-		SupplyHistory::<T>::get(id).map_or_else(default, |history| {
+		history.map_or_else(default, |history| {
 			history.range(..=block).next_back().map(|item| *item.1).or_else(default)
 		})
 	}
 
 	pub(super) fn update_supply_history(id: T::AssetId, supply: T::Balance) {
-		let mut history = SupplyHistory::<T>::get(id).unwrap_or_default();
+		// update history
+		let history = Self::update_history(SupplyHistory::<T>::get(id).unwrap_or_default(), supply);
+
+		// record new history
+		SupplyHistory::<T>::insert(id, history);
+	}
+
+	pub(super) fn update_account_history(id: T::AssetId, who: &T::AccountId, balance: T::Balance) {
+		// update history
+		let history =
+			Self::update_history(AccountHistory::<T>::get(id, who).unwrap_or_default(), balance);
+
+		// record new history
+		AccountHistory::<T>::insert(id, who, history);
+	}
+
+	fn update_history<V: Copy + Debug + Zero, B: Get<u32>>(
+		mut history: BoundedBTreeMap<BlockNumberFor<T>, V, B>,
+		value: V,
+	) -> BoundedBTreeMap<BlockNumberFor<T>, V, B> {
 		let current_block = frame_system::Pallet::<T>::block_number();
 
 		// the oldest block for which we need to be able to retrieve history
@@ -94,10 +134,8 @@ impl<T: Config> Pallet<T> {
 		}
 
 		// insert new history item
-		history.try_insert(current_block, supply).expect("Enough space has been freed");
-
-		// record new history
-		SupplyHistory::<T>::insert(id, history);
+		history.try_insert(current_block, value).expect("Enough space has been freed");
+		history
 	}
 
 	pub(super) fn new_account(
@@ -121,22 +159,26 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub(super) fn dead_account(
+		id: T::AssetId,
 		who: &T::AccountId,
-		d: &mut AssetDetailsOf<T>,
+		details: &mut AssetDetailsOf<T>,
 		reason: &ExistenceReason<DepositBalanceOf<T>>,
 		force: bool,
 	) -> DeadConsequence {
 		match *reason {
 			ExistenceReason::Consumer => frame_system::Pallet::<T>::dec_consumers(who),
 			ExistenceReason::Sufficient => {
-				d.sufficients = d.sufficients.saturating_sub(1);
+				details.sufficients.saturating_dec();
 				frame_system::Pallet::<T>::dec_sufficients(who);
 			},
 			ExistenceReason::DepositRefunded => {},
 			ExistenceReason::DepositHeld(_) if !force => return Keep,
-			ExistenceReason::DepositHeld(_) => {},
+			ExistenceReason::DepositHeld(deposit) => {
+				T::Currency::unreserve(&who, deposit);
+			},
 		}
-		d.accounts = d.accounts.saturating_sub(1);
+		details.accounts.saturating_dec();
+		AccountHistory::<T>::remove(id, &who);
 		Remove
 	}
 
@@ -202,12 +244,8 @@ impl<T: Config> Pallet<T> {
 			None => return NoFunds,
 		};
 		if let Some(rest) = account.balance.checked_sub(&amount) {
-			let is_provider = false;
-			let is_required = is_provider && !frame_system::Pallet::<T>::can_dec_provider(who);
-			let must_keep_alive = keep_alive || is_required;
-
 			if rest < details.min_balance {
-				if must_keep_alive {
+				if keep_alive {
 					WouldDie
 				} else {
 					ReducedToZero(rest)
@@ -232,9 +270,7 @@ impl<T: Config> Pallet<T> {
 
 		let account = Account::<T>::get(id, who).ok_or(Error::<T>::NoAccount)?;
 		let amount = {
-			let is_provider = false;
-			let is_required = is_provider && !frame_system::Pallet::<T>::can_dec_provider(who);
-			if keep_alive || is_required {
+			if keep_alive {
 				// We want to keep the account around.
 				account.balance.saturating_sub(details.min_balance)
 			} else {
@@ -309,14 +345,14 @@ impl<T: Config> Pallet<T> {
 		Ok((credit, maybe_burn))
 	}
 
-	/// Creates a account for `who` to hold asset `id` with a zero balance and takes a deposit.
+	/// Creates an account for `who` to hold asset `id` with a zero balance and takes a deposit.
 	pub(super) fn do_touch(id: T::AssetId, who: T::AccountId) -> DispatchResult {
 		ensure!(!Account::<T>::contains_key(id, &who), Error::<T>::AlreadyExists);
 		let deposit = T::AssetAccountDeposit::get();
 		let mut details = Asset::<T>::get(id).ok_or(Error::<T>::Unknown)?;
 		ensure!(details.status == AssetStatus::Live, Error::<T>::AssetNotLive);
-		let reason = Self::new_account(&who, &mut details, Some(deposit))?;
 		T::Currency::reserve(&who, deposit)?;
+		let reason = Self::new_account(&who, &mut details, Some(deposit))?;
 		Asset::<T>::insert(id, details);
 		Account::<T>::insert(
 			id,
@@ -398,23 +434,18 @@ impl<T: Config> Pallet<T> {
 			ensure!(details.status == AssetStatus::Live, Error::<T>::AssetNotLive);
 			check(details)?;
 
-			Account::<T>::try_mutate(id, beneficiary, |maybe_account| -> DispatchResult {
-				match maybe_account {
-					Some(ref mut account) => {
-						account.balance.saturating_accrue(amount);
-					},
-					maybe_account @ None => {
-						// Note this should never fail as it's already checked by `can_increase`.
-						ensure!(amount >= details.min_balance, TokenError::BelowMinimum);
-						*maybe_account = Some(AssetAccountOf::<T> {
-							balance: amount,
-							reserved: Zero::zero(),
-							reason: Self::new_account(beneficiary, details, None)?,
-						});
-					},
-				}
-				Ok(())
-			})?;
+			let mut account = match Account::<T>::get(id, beneficiary) {
+				Some(account) => account,
+				None => AssetAccountOf::<T> {
+					balance: Zero::zero(),
+					reserved: Zero::zero(),
+					reason: Self::new_account(beneficiary, details, None)?,
+				},
+			};
+			account.balance.saturating_accrue(amount);
+			ensure!(account.balance >= details.min_balance, TokenError::BelowMinimum);
+			Self::update_account_history(id, beneficiary, account.balance);
+			Account::<T>::insert(id, beneficiary, account);
 			Ok(())
 		})?;
 		Ok(())
@@ -477,29 +508,23 @@ impl<T: Config> Pallet<T> {
 		ensure!(details.status == AssetStatus::Live, Error::<T>::AssetNotLive);
 
 		let actual = Self::prep_debit(id, target, amount, f)?;
-		let mut target_died: Option<DeadConsequence> = None;
 
 		Asset::<T>::try_mutate(id, |maybe_details| -> DispatchResult {
 			let details = maybe_details.as_mut().ok_or(Error::<T>::Unknown)?;
 			check(actual, details)?;
 
-			Account::<T>::try_mutate(id, target, |maybe_account| -> DispatchResult {
-				let mut account = maybe_account.take().ok_or(Error::<T>::NoAccount)?;
-				debug_assert!(account.balance >= actual, "checked in prep; qed");
-
-				// Make the debit.
-				account.balance = account.balance.saturating_sub(actual);
-				if account.balance < details.min_balance {
-					debug_assert!(account.balance.is_zero(), "checked in prep; qed");
-					target_died = Some(Self::dead_account(target, details, &account.reason, false));
-					if let Some(Remove) = target_died {
-						return Ok(())
-					}
-				};
-				*maybe_account = Some(account);
-				Ok(())
-			})?;
-
+			let mut account = Account::<T>::take(id, target).ok_or(Error::<T>::NoAccount)?;
+			debug_assert!(account.balance >= actual, "checked in prep; qed");
+			account.balance.saturating_reduce(actual);
+			if account.balance < details.min_balance &&
+				// account already removed by take
+				Remove == Self::dead_account(id, target, details, &account.reason, false)
+			{
+				debug_assert!(account.balance.is_zero(), "checked in prep; qed");
+				return Ok(())
+			};
+			Self::update_account_history(id, target, account.balance);
+			Account::<T>::insert(id, target, account);
 			Ok(())
 		})?;
 
@@ -593,8 +618,6 @@ impl<T: Config> Pallet<T> {
 		let debit = Self::prep_debit(id, source, amount, f.into())?;
 		let (credit, maybe_burn) = Self::prep_credit(id, dest, amount, debit, f.burn_dust)?;
 
-		let mut source_account = Account::<T>::get(id, source).ok_or(Error::<T>::NoAccount)?;
-
 		Asset::<T>::try_mutate(id, |maybe_details| -> DispatchResult {
 			let details = maybe_details.as_mut().ok_or(Error::<T>::Unknown)?;
 
@@ -617,41 +640,34 @@ impl<T: Config> Pallet<T> {
 			}
 
 			// Debit balance from source; this will not saturate since it's already checked in prep.
+			let mut source_account = Account::<T>::get(id, source).expect("checked in prep; qed");
 			debug_assert!(source_account.balance >= debit, "checked in prep; qed");
-			source_account.balance = source_account.balance.saturating_sub(debit);
+			source_account.balance.saturating_reduce(debit);
 
-			Account::<T>::try_mutate(id, dest, |maybe_account| -> DispatchResult {
-				match maybe_account {
-					Some(ref mut account) => {
-						// Calculate new balance; this will not saturate since it's already checked
-						// in prep.
-						debug_assert!(
-							account.balance.checked_add(&credit).is_some(),
-							"checked in prep; qed"
-						);
-						account.balance.saturating_accrue(credit);
-					},
-					maybe_account @ None => {
-						*maybe_account = Some(AssetAccountOf::<T> {
-							balance: credit,
-							reserved: Zero::zero(),
-							reason: Self::new_account(dest, details, None)?,
-						});
-					},
-				}
-				Ok(())
-			})?;
+			let mut account = match Account::<T>::get(id, dest) {
+				Some(account) => account,
+				None => AssetAccountOf::<T> {
+					balance: Zero::zero(),
+					reserved: Zero::zero(),
+					reason: Self::new_account(dest, details, None)?,
+				},
+			};
+			// Calculate new balance; this will not saturate since it's already checked in prep.
+			debug_assert!(account.balance.checked_add(&credit).is_some(), "checked in prep; qed");
+			account.balance.saturating_accrue(credit);
+			Self::update_account_history(id, dest, account.balance);
+			Account::<T>::insert(id, dest, account);
 
 			// Remove source account if it's now dead.
 			if source_account.balance < details.min_balance {
 				debug_assert!(source_account.balance.is_zero(), "checked in prep; qed");
-				if let Some(Remove) =
-					Some(Self::dead_account(source, details, &source_account.reason, false))
+				if Remove == Self::dead_account(id, source, details, &source_account.reason, false)
 				{
 					Account::<T>::remove(id, source);
 					return Ok(())
 				}
 			}
+			Self::update_account_history(id, source, source_account.balance);
 			Account::<T>::insert(id, source, &source_account);
 			Ok(())
 		})?;
@@ -738,12 +754,10 @@ impl<T: Config> Pallet<T> {
 			// Should only destroy accounts while the asset is in a destroying state
 			ensure!(details.status == AssetStatus::Destroying, Error::<T>::IncorrectStatus);
 
-			for (who, v) in Account::<T>::drain_prefix(id) {
-				let _ = Self::dead_account(&who, details, &v.reason, true);
+			for (who, v) in Account::<T>::drain_prefix(id).take(max_items.try_into().unwrap()) {
+				// account already removed by drain
+				let _ = Self::dead_account(id, &who, details, &v.reason, true);
 				dead_accounts += 1;
-				if dead_accounts >= max_items {
-					break
-				}
 			}
 			remaining_accounts = details.accounts;
 			Ok(())

--- a/pallets/dao-assets/src/lib.rs
+++ b/pallets/dao-assets/src/lib.rs
@@ -222,6 +222,17 @@ pub mod pallet {
 		BoundedBTreeMap<BlockNumberFor<T>, AssetBalanceOf<T>, T::HistoryHorizon>,
 	>;
 
+	#[pallet::storage]
+	/// History for the total balance of each account for all assets.
+	pub(super) type AccountHistory<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		T::AssetId,
+		Blake2_128Concat,
+		T::AccountId,
+		BoundedBTreeMap<BlockNumberFor<T>, AssetBalanceOf<T>, T::HistoryHorizon>,
+	>;
+
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		/// Genesis assets: id, owner, is_sufficient, min_balance

--- a/pallets/dao-assets/src/lib.rs
+++ b/pallets/dao-assets/src/lib.rs
@@ -42,6 +42,7 @@ use frame_support::{
 		BalanceStatus::Reserved,
 		Currency, EnsureOriginWithArg, ReservableCurrency,
 	},
+	BoundedBTreeMap,
 };
 use frame_system::Config as SystemConfig;
 
@@ -154,6 +155,12 @@ pub mod pallet {
 		#[pallet::constant]
 		type StringLimit: Get<u32>;
 
+		/// The age for which historical data may be removed.
+		/// For example, if this is 100 and the current block is 150,
+		/// then history for blocks 50 and older may be removed.
+		#[pallet::constant]
+		type HistoryHorizon: Get<u32>;
+
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 
@@ -204,6 +211,15 @@ pub mod pallet {
 		T::AssetId,
 		AssetMetadata<DepositBalanceOf<T>, BoundedVec<u8, T::StringLimit>>,
 		ValueQuery,
+	>;
+
+	#[pallet::storage]
+	/// History for the total supply across all accounts.
+	pub(super) type SupplyHistory<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::AssetId,
+		BoundedBTreeMap<BlockNumberFor<T>, AssetBalanceOf<T>, T::HistoryHorizon>,
 	>;
 
 	#[pallet::genesis_config]

--- a/pallets/dao-assets/src/mock.rs
+++ b/pallets/dao-assets/src/mock.rs
@@ -81,6 +81,7 @@ impl Config for Test {
 	type MetadataDepositPerByte = ConstU64<1>;
 	type ApprovalDeposit = ConstU64<1>;
 	type StringLimit = ConstU32<50>;
+	type HistoryHorizon = ConstU32<30>;
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<5>;
 	#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/dao-core/src/mock.rs
+++ b/pallets/dao-core/src/mock.rs
@@ -97,6 +97,7 @@ impl pallet_dao_assets::Config for Test {
 	type ApprovalDeposit = ApprovalDeposit;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type StringLimit = AssetsStringLimit;
+	type HistoryHorizon = ConstU32<4200>;
 	type WeightInfo = ();
 }
 

--- a/pallets/dao-votes/src/mock.rs
+++ b/pallets/dao-votes/src/mock.rs
@@ -96,6 +96,7 @@ impl pallet_dao_assets::Config for Test {
 	type ApprovalDeposit = ApprovalDeposit;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type StringLimit = AssetsStringLimit;
+	type HistoryHorizon = ConstU32<4200>;
 	type WeightInfo = ();
 }
 

--- a/pallets/dao-votes/src/tests.rs
+++ b/pallets/dao-votes/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{mock::*, Config, Error, Proposals};
+use crate::{mock::*, types::*, Config, Error, Proposals};
 use frame_support::{assert_noop, assert_ok, traits::TypedGet, BoundedVec};
 use frame_system::ensure_signed;
 use pallet_dao_core::{CurrencyOf, Error as DaoError};
@@ -164,6 +164,55 @@ fn run_to_block(n: u64) {
 }
 
 #[test]
+fn can_fault_a_proposal() {
+	new_test_ext().execute_with(|| {
+		let prop_id = b"PROP".to_vec();
+		let origin = RuntimeOrigin::signed(1);
+		let reason = b"Bad".to_vec();
+		assert_noop!(
+			DaoVotes::fault_proposal(origin.clone(), prop_id.clone(), reason.clone()),
+			Error::<Test>::ProposalDoesNotExist
+		);
+		let dao_id = b"DAO".to_vec();
+		let dao_name = b"TEST DAO".to_vec();
+		let metadata = b"http://my.cool.proposal".to_vec();
+		// https://en.wikipedia.org/wiki/SHA-3#Examples_of_SHA-3_variants
+		let hash = b"a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a".to_vec();
+		// preparation: create a DAO
+		assert_ok!(DaoCore::create_dao(origin.clone(), dao_id.clone(), dao_name));
+		// preparation: issue token
+		assert_ok!(DaoCore::issue_token(origin.clone(), dao_id.clone(), 1000));
+		// preparation: set governance
+		let duration = 4200;
+		let token_deposit = 100;
+		let minimum_majority_per_256 = 3; // slightly more than 1 %
+		assert_ok!(DaoVotes::set_governance_majority_vote(
+			origin.clone(),
+			dao_id.clone(),
+			duration,
+			token_deposit,
+			minimum_majority_per_256
+		));
+		// preparation: create a proposal
+		assert_ok!(DaoVotes::create_proposal(
+			origin.clone(),
+			dao_id,
+			prop_id.clone(),
+			metadata,
+			hash
+		));
+
+		let non_owner = RuntimeOrigin::signed(35);
+		assert_noop!(
+			DaoVotes::fault_proposal(non_owner, prop_id.clone(), reason.clone()),
+			Error::<Test>::SenderIsNotDaoOwner,
+		);
+
+		assert_ok!(DaoVotes::fault_proposal(origin, prop_id, reason));
+	})
+}
+
+#[test]
 fn can_finalize_a_proposal() {
 	new_test_ext().execute_with(|| {
 		let dao_id = b"DAO".to_vec();
@@ -225,17 +274,13 @@ fn can_finalize_a_proposal() {
 }
 
 #[test]
-fn can_fault_a_proposal() {
+fn voting_outcome_unsuccessful_proposal() {
 	new_test_ext().execute_with(|| {
-		let prop_id = b"PROP".to_vec();
-		let origin = RuntimeOrigin::signed(1);
-		let reason = b"Bad".to_vec();
-		assert_noop!(
-			DaoVotes::fault_proposal(origin.clone(), prop_id.clone(), reason.clone()),
-			Error::<Test>::ProposalDoesNotExist
-		);
 		let dao_id = b"DAO".to_vec();
 		let dao_name = b"TEST DAO".to_vec();
+		let prop_id = b"PROP".to_vec();
+		let origin = RuntimeOrigin::signed(1);
+
 		let metadata = b"http://my.cool.proposal".to_vec();
 		// https://en.wikipedia.org/wiki/SHA-3#Examples_of_SHA-3_variants
 		let hash = b"a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a".to_vec();
@@ -244,9 +289,9 @@ fn can_fault_a_proposal() {
 		// preparation: issue token
 		assert_ok!(DaoCore::issue_token(origin.clone(), dao_id.clone(), 1000));
 		// preparation: set governance
-		let duration = 4200;
+		let duration = 0;
 		let token_deposit = 100;
-		let minimum_majority_per_256 = 3; // slightly more than 1 %
+		let minimum_majority_per_256 = 0;
 		assert_ok!(DaoVotes::set_governance_majority_vote(
 			origin.clone(),
 			dao_id.clone(),
@@ -262,13 +307,65 @@ fn can_fault_a_proposal() {
 			metadata,
 			hash
 		));
+		let voter = 2;
+		//dbg!(Assets::balance(origin
+		assert_ok!(Assets::transfer(origin.clone(), 1, voter, 500));
+		assert_ok!(DaoVotes::vote(RuntimeOrigin::signed(voter), prop_id.clone(), true));
+		assert_ok!(DaoVotes::vote(origin.clone(), prop_id.clone(), false));
 
-		let non_owner = RuntimeOrigin::signed(35);
-		assert_noop!(
-			DaoVotes::fault_proposal(non_owner, prop_id.clone(), reason.clone()),
-			Error::<Test>::SenderIsNotDaoOwner,
-		);
+		let block = System::block_number() + 1 + duration as u64;
+		run_to_block(block);
+		assert_ok!(DaoVotes::finalize_proposal(origin, prop_id.clone()));
+		let bounded_prop_id: BoundedVec<_, _> = prop_id.try_into().unwrap();
+		let proposal = Proposals::<Test>::get(bounded_prop_id).unwrap();
+		assert_eq!(proposal.status, ProposalStatus::Rejected);
+	})
+}
 
-		assert_ok!(DaoVotes::fault_proposal(origin, prop_id, reason));
+#[test]
+fn voting_outcome_successful_proposal() {
+	new_test_ext().execute_with(|| {
+		let dao_id = b"DAO".to_vec();
+		let dao_name = b"TEST DAO".to_vec();
+		let prop_id = b"PROP".to_vec();
+		let origin = RuntimeOrigin::signed(1);
+
+		let metadata = b"http://my.cool.proposal".to_vec();
+		// https://en.wikipedia.org/wiki/SHA-3#Examples_of_SHA-3_variants
+		let hash = b"a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a".to_vec();
+		// preparation: create a DAO
+		assert_ok!(DaoCore::create_dao(origin.clone(), dao_id.clone(), dao_name));
+		// preparation: issue token
+		assert_ok!(DaoCore::issue_token(origin.clone(), dao_id.clone(), 1001));
+		// preparation: set governance
+		let duration = 0;
+		let token_deposit = 100;
+		let minimum_majority_per_256 = 0;
+		assert_ok!(DaoVotes::set_governance_majority_vote(
+			origin.clone(),
+			dao_id.clone(),
+			duration,
+			token_deposit,
+			minimum_majority_per_256
+		));
+		// preparation: create a proposal
+		assert_ok!(DaoVotes::create_proposal(
+			origin.clone(),
+			dao_id,
+			prop_id.clone(),
+			metadata,
+			hash
+		));
+		let voter = 2;
+		assert_ok!(Assets::transfer(origin.clone(), 1, voter, 501));
+		assert_ok!(DaoVotes::vote(RuntimeOrigin::signed(voter), prop_id.clone(), true));
+		assert_ok!(DaoVotes::vote(origin.clone(), prop_id.clone(), false));
+
+		let block = System::block_number() + 1 + duration as u64;
+		run_to_block(block);
+		assert_ok!(DaoVotes::finalize_proposal(origin, prop_id.clone()));
+		let bounded_prop_id: BoundedVec<_, _> = prop_id.try_into().unwrap();
+		let proposal = Proposals::<Test>::get(bounded_prop_id).unwrap();
+		assert_eq!(proposal.status, ProposalStatus::Accepted);
 	})
 }

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -327,6 +327,7 @@ impl pallet_dao_assets::Config for Runtime {
 	type ApprovalDeposit = ApprovalDeposit;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type StringLimit = AssetsStringLimit;
+	type HistoryHorizon = ConstU32<5000>;
 	type WeightInfo = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 


### PR DESCRIPTION
This introduces the HistoryHorizon constant which determines the minimum number of blocks that we keep history for, together with SupplyHistory and AccountHistory, which record historical supply and account balances.

Further work is needed to make the proposal voting outcome calculation use this.

BTW: An [offchain workers](https://paritytech.github.io/substrate/master/frame_support/traits/trait.Hooks.html#method.offchain_worker) may be another way to go about this, since it could query the historical data that is preserved in the blockchain. It may be possible to use that to determine the outcome of voting on proposals. Or maybe not, I don't know enough about it, but wanted to mention it anyway.